### PR TITLE
Fix an issue which would cause Wine to hang in the event of a crash

### DIFF
--- a/build/template/template.dockerfile.j2
+++ b/build/template/template.dockerfile.j2
@@ -435,3 +435,7 @@ RUN wine64 reg add "HKLM\\SOFTWARE\\Microsoft\\VSCommon\\17.0\\SQM" /f /v OptIn 
 RUN wine64 reg add "HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\VSCommon\\17.0\\SQM" /f /v OptIn /t REG_DWORD /d 0 && wineserver --wait
 
 {% endif %}
+
+# Prevent Wine from attempting to display a dialog box in the event of a crash
+# (Without this, execution may hang when running with Xvfb in a headless environment)
+RUN wine64 reg add "HKCU\\Software\\Wine\\WineDbg" /f /v ShowCrashDialog /t REG_DWORD /d 0 && wineserver --wait


### PR DESCRIPTION
This change disables the "Crash Dialog" that would normally appear in the event of an unhandled exception. This would cause Wine to hang when it attempts to launch the dialog while running with virtual framebuffer.