### PR TITLE
Allow exempting some processes from overcommit

### DIFF
--- a/libmemory-patches/libmemory-patches.h
+++ b/libmemory-patches/libmemory-patches.h
@@ -40,6 +40,7 @@ struct current_memory_info
 
 LIBMEMORY_PATCHES_API extern struct current_memory_info get_current_memory_info(void);
 LIBMEMORY_PATCHES_API int overcommit_prevention_enabled(void);
+LIBMEMORY_PATCHES_API int overcommit_prevention_exempt(void);
 LIBMEMORY_PATCHES_API BOOL memory_available_for_commit(size_t size);
 LIBMEMORY_PATCHES_API void touch_committed_pages(void* base, size_t size, uint32_t protect);
 LIBMEMORY_PATCHES_API BOOL has_write_flags(uint32_t protect);

--- a/patches/wine-overcommit-prevention-support.patch
+++ b/patches/wine-overcommit-prevention-support.patch
@@ -241,7 +241,7 @@ index abe1b4dc4ec424c0864d18e726537e680d2ab883..e55d7e68d1b8d3967316f1101cb0ce9b
          VIRTUAL_DEBUG_DUMP_VIEW( view );
 +
 +        /* if overcommit prevention is enabled and we performed a commit, then touch the commited pages */
-+        if (write_consumes_memory && overcommit_prevention_enabled()) {
++        if (write_consumes_memory && (overcommit_prevention_enabled() || overcommit_prevention_exempt())) {
 +            touch_committed_pages(view->base, size, protect);
 +        }
      }
@@ -267,7 +267,7 @@ index abe1b4dc4ec424c0864d18e726537e680d2ab883..e55d7e68d1b8d3967316f1101cb0ce9b
          *size_ptr = size;
 +
 +        /* if overcommit prevention is enabled and we performed a commit, then touch the commited pages */
-+        if ((type & MEM_COMMIT) && overcommit_prevention_enabled()) {
++        if ((type & MEM_COMMIT) && (overcommit_prevention_enabled() || overcommit_prevention_exempt())) {
 +            touch_committed_pages(base, size, protect);
 +        }
      }
@@ -295,7 +295,7 @@ index abe1b4dc4ec424c0864d18e726537e680d2ab883..e55d7e68d1b8d3967316f1101cb0ce9b
              status = set_protection( view, base, size, new_prot );
 +
 +            /* if overcommit prevention is enabled and write access was granted then touch the pages */
-+            if (overcommit_prevention_enabled() && write_or_copy_added) {
++            if ((overcommit_prevention_enabled() || overcommit_prevention_exempt()) && write_or_copy_added) {
 +                touch_committed_pages(base, size, new_prot);
 +            }
          }


### PR DESCRIPTION
This allows you to set e.g. `WINE_PREVENT_OVERCOMMIT_EXEMPT=ubaagent.exe` to exempt some processes from Wine overcommit prevention.

This is necessary for UbaAgent, which can not tolerate memory allocation failures under some circumstances. In particular, `Session::ProcessExited` in UbaAgent will occur when processes are exiting due to memory pressure, and this function allocates through the `m_deadProcesses.emplace_back` call. When Wine overcommit prevention is enabled, the underlying `mi_malloc_aligned` call from `emplace_back` can return `nullptr`, resulting in a segmentation fault.