### PR TITLE
Fix missing DSC file which is used to identify Wine's build dependencies

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -99,6 +99,7 @@ class Utility:
 script_dir = Path(__file__).parent
 template_dir = script_dir / 'template'
 context_dir = script_dir / 'context'
+dependencies_dir = script_dir / 'dependencies'
 patches_dir = script_dir.parent / 'patches'
 shim_dir = script_dir.parent / 'memory-shim'
 libmemory_patches_dir = script_dir.parent / 'libmemory-patches'
@@ -196,6 +197,11 @@ shutil.copytree(shim_dir, copied_shim)
 copied_libmemory_patches = context_dir / 'libmemory-patches'
 Utility.delete_if_exists(copied_libmemory_patches)
 shutil.copytree(libmemory_patches_dir, copied_libmemory_patches)
+
+# Copy the build dependencies into the build context directory
+copied_dependencies = context_dir / 'dependencies'
+Utility.delete_if_exists(copied_dependencies)
+shutil.copytree(dependencies_dir, copied_dependencies)
 
 # Remove the Wine patches README from the build context
 Utility.delete_if_exists(copied_patches / 'README.md')

--- a/build/dependencies/wine-deps.dsc
+++ b/build/dependencies/wine-deps.dsc
@@ -1,0 +1,33 @@
+Package: wine
+Binary: wine-devel-i386, wine-devel-amd64, wine-devel, wine-devel-dev, wine-devel-dbg, winehq-devel
+Version: 10.1~jammy-1
+Maintainer: Rosanne DiMesio <dimesio@earthlink.net>, Marcus Meissner <meissner@suse.com>
+Original-Maintainer: WineHQ Builds <webmaster@fds-team.de>
+Build-Depends: autotools-dev, autoconf, bison, docbook-to-man, docbook-utils, docbook-xsl, flex, fontforge, gawk, gcc, gettext, libacl1-dev, libasound2-dev, libcups2-dev, libdbus-1-dev, libfontconfig1-dev | libfontconfig-dev, libfreetype6-dev, libgl1-mesa-dev, libglu1-mesa-dev, libgnutls30-dev | libgnutls28-dev | libgnutls-dev, libgphoto2-dev | libgphoto2-6-dev | libgphoto2-2-dev (>= 2.4.6), libgtk-3-dev, libice-dev, libkrb5-dev, libncurses6-dev | libncurses5-dev | libncurses-dev, libosmesa6-dev, libpcap-dev, libpulse-dev, libsane-dev, libsdl2-dev, libssl-dev, libstdc++6-4.5-dev | libstdc++-dev, libudev-dev, libv4l-dev, libx11-dev, libxcomposite-dev, libxcursor-dev, libxext-dev, libxi-dev, libxinerama-dev, libxrandr-dev, libxrender-dev, libxt-dev, libxxf86vm-dev, linux-libc-dev, ocl-icd-opencl-dev, patch, perl, sharutils, unixodbc-dev, x11proto-xinerama-dev
+Architecture: i386 amd64 armhf
+Standards-Version: 3.9.5
+Format: 3.0 (quilt)
+Directory: pool/main/w/wine
+Files:
+ 5572f28f619803590d1fce07c9f78145 5400 wine_10.1~jammy-1.debian.tar.xz
+ e1042f2f2b57eee1e06d17874bceb281 2107 wine_10.1~jammy-1.dsc
+ 70c6a7333db73ed1e7e3a93adb22ca60 51979546 wine_10.1~jammy.orig.tar.gz
+Checksums-Sha1:
+ 23b179b7e7e1a817fc4b13dbb522a50b0d3cfb4e 5400 wine_10.1~jammy-1.debian.tar.xz
+ c3f92dc099164e63ee3421ccf80dc04a57c0bfe0 2107 wine_10.1~jammy-1.dsc
+ 2d916715ac6c3505bc28bddd86cb332ad0687c23 51979546 wine_10.1~jammy.orig.tar.gz
+Checksums-Sha256:
+ 1b59a376770e896e7df1be5c6ee130eed58355345d7854e2543fcba3e02f8c1c 5400 wine_10.1~jammy-1.debian.tar.xz
+ 0cca0d6d38f433f9f565d8ae504c066e26b3b9c3be9dc1586b1330151a41a341 2107 wine_10.1~jammy-1.dsc
+ 325bcdb450b8f812a36c38dad6dcc796d53d094bd91baeb70a559823d7bbe2ca 51979546 wine_10.1~jammy.orig.tar.gz
+Checksums-Sha512:
+ d05fca56d6d6b0c69be9ffcb0766997dd205c0fa53d79d891031c2c24c6b636f66018e53c515ebf61c46385b08c8872a2811bb987cc421b54e1c9a8e2c013d64 5400 wine_10.1~jammy-1.debian.tar.xz
+ 7d4a5aae12a7c45f661ea6211ea30cde0ae34180ca5c206208779cdd28f2118cf3b19f890af8cdb3d5c896051096ffd057c56449a2a50dc2c79e5a0f9958d344 2107 wine_10.1~jammy-1.dsc
+ 59ff932a176aa80a7aa0fe4aa0099dd989ec1c4c26ee28ee5540206bafaf8dbac577bd34c86debb83a1b672378c65000183b55574279688abdde1762d2fa447f 51979546 wine_10.1~jammy.orig.tar.gz
+Package-List:
+ wine-devel deb otherosfs optional arch=i386,amd64
+ wine-devel-amd64 deb otherosfs optional arch=amd64
+ wine-devel-dbg deb debug optional arch=i386,amd64
+ wine-devel-dev deb libdevel optional arch=i386,amd64,armhf
+ wine-devel-i386 deb otherosfs optional arch=i386
+ winehq-devel deb otherosfs optional arch=i386,amd64

--- a/build/template/template.dockerfile.j2
+++ b/build/template/template.dockerfile.j2
@@ -61,7 +61,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 
 
 # Retrieve the list of build prerequisites for the selected version of Wine
-RUN curl -fSL "https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/main/source/wine_{{ TEMPLATE_WINE_PACKAGE_VERSION }}~jammy-1.dsc" -o /tmp/wine-deps.dsc
+# Note: This file no longer exists at the URL below, so a copy has been added to this repo instead
+# RUN curl -fSL "https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/main/source/wine_{{ TEMPLATE_WINE_PACKAGE_VERSION }}~jammy-1.dsc" -o /tmp/wine-deps.dsc
+COPY dependencies/wine-deps.dsc /tmp/wine-deps.dsc
 
 # Install the 64-bit versions of the build prerequisites
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \


### PR DESCRIPTION
The DSC file which is used to identify Wine's build dependencies no longer exists at the URL `https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/main/source/wine_10.1~jammy-1.dsc`. This was being fetched during the Docker build process, and as a result builds are failing. A copy of the file has been added to this repository instead to address this problem.