### PR TITLE
Fix Incorrect return-value check for a 'scanf'-like function cgroups

### DIFF
--- a/libmemory-patches/cgroups.c
+++ b/libmemory-patches/cgroups.c
@@ -626,11 +626,11 @@ struct current_memory_info get_current_memory_info(void)
                     current_mem_info.totalswap += value * 1024;
                 else if(sscanf(line, "SwapFree: %llu kB", &value) == 1)
                     current_mem_info.freeswap += value * 1024;
-                else if (sscanf(line, "Buffers: %llu", &value))
+                else if (sscanf(line, "Buffers: %llu", &value) == 1)
                     current_mem_info.freeram += value * 1024;
-                else if (sscanf(line, "Cached: %llu", &value))
+                else if (sscanf(line, "Cached: %llu", &value) == 1)
                     current_mem_info.freeram += value * 1024;
-                else if (sscanf(line, "MemAvailable: %llu", &value))
+                else if (sscanf(line, "MemAvailable: %llu", &value) == 1)
                     mem_available = value * 1024;
             }
             fclose(fp);


### PR DESCRIPTION
https://github.com/EpicGamesExt/WineResources/blob/017b20a911bd5c4c94ffcc74fd134b93e6d10726/libmemory-patches/cgroups.c#L633-L633

This query finds calls of `scanf`- like functions with improper return-value checking. Specifically, it flags uses of `scanf` where the return value is only checked against zero. functions in the `scanf` family return either `EOF` (a negative value) in case of IO failure, or the number of items successfully read from the input. Consequently, a simple check that the return value is nonzero is not enough.



The issue can be fixed by explicitly checking the return value of `sscanf` against the expected number of successful matches (which is `1` in this case). If `sscanf` does not return `1`, the code should skip processing the invalid data for the corresponding line. This ensures robustness and prevents undefined behavior or incorrect calculations.


#### References
SEI CERT C++ Coding Standard: [ERR62-CPP. Detect errors when converting a string to a number](https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR62-CPP.+Detect+errors+when+converting+a+string+to+a+number)
SEI CERT C Coding Standard: [ERR33-C. Detect and handle standard library errors](https://wiki.sei.cmu.edu/confluence/display/c/ERR33-C.+Detect+and+handle+standard+library+errors)
cppreference.com: [scanf, fscanf, sscanf, scanf_s, fscanf_s, sscanf_s](https://en.cppreference.com/w/c/io/fscanf)
