### PR TITLE
Updates the Dockerfile template to include 32-bit dependencies for X11 extensions

### DIFF
--- a/build/template/template.dockerfile.j2
+++ b/build/template/template.dockerfile.j2
@@ -349,7 +349,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 		libgnutls30:i386 \
 		libgnutlsxx28:i386 \
 		libgnutls-openssl27:i386 \
-		libvulkan1:i386
+		libvulkan1:i386 \
+		libxext6:i386
 
 {% endif %}
 


### PR DESCRIPTION
This PR updates the Dockerfile template to include the `libxext6:i386` library in the list of development dependencies for 32-bit builds.

**Changes:**
- Added `libxext6:i386` to the `apt` install list alongside existing 32-bit libraries.

Including `libxext6:i386` ensures that Wine has access to the required 32-bit X11 extension libraries. This prevents runtime errors related to window creation or graphics initialisation when building or running 32-bit Windows applications under Wine inside the container.

**Impact:**
- Fixes `nodrv_CreateWindow` and potentially other graphics-related errors in Wine for 32-bit applications.

**Testing:**
- Verified that 32-bit Wine applications (specifically, .NET installers) now start successfully under `xvfb`.

**Notes:**
- It's worth a mention that when running a .NET installer, it should be executed from within its residing directory, otherwise it will fail when it attempts to create its temporary 'working environment' as it will not be able to resolve paths correctly.
