### PR TITLE
Make logging in libmemory-patches configurable

### DIFF
--- a/build/template/template.dockerfile.j2
+++ b/build/template/template.dockerfile.j2
@@ -187,12 +187,12 @@ RUN git clone --progress --depth=1 -b "{{ TEMPLATE_WINE_RELEASE_TAG }}" 'https:/
 # Build libmemory-patches
 COPY --chown=nonroot:nonroot libmemory-patches /tmp/libmemory-patches
 RUN cd /tmp/libmemory-patches/ && \
-	gcc -std=c99 -shared -O2 -fvisibility=hidden "-I$WINE_SOURCE/include" -fPIC -o libmemory-patches64.so cgroups.c overcommit.c -lcgroup && \
+	gcc -std=c99 -shared -O2 -fvisibility=hidden "-I$WINE_SOURCE/include" -fPIC -o libmemory-patches64.so cgroups.c logger.c overcommit.c -lcgroup && \
 	cp libmemory-patches64.so /lib/x86_64-linux-gnu/libmemory-patches.so && \
 	cp libmemory-patches.h /usr/include/
 {% if TEMPLATE_ENABLE_32_BIT_SUPPORT %}
 RUN cd /tmp/libmemory-patches/ && \
-	gcc -std=c99 -shared -O2 -fvisibility=hidden "-I$WINE_SOURCE/include" -m32 -o libmemory-patches32.so cgroups.c overcommit.c -lcgroup && \
+	gcc -std=c99 -shared -O2 -fvisibility=hidden "-I$WINE_SOURCE/include" -m32 -o libmemory-patches32.so cgroups.c logger.c overcommit.c -lcgroup && \
 	cp libmemory-patches32.so /usr/lib/i386-linux-gnu/libmemory-patches.so
 {% endif %}
 

--- a/libmemory-patches/logger.c
+++ b/libmemory-patches/logger.c
@@ -1,0 +1,35 @@
+#include "logger.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+log_level get_log_level(void)
+{
+    static int level = -1;
+
+    if (level == -1)
+    {
+        const char *str = getenv( "LIBMEMORY_PATCHES_LOG_LEVEL" );
+
+        if (str)
+        {
+            level = atoi(str);
+            if (level != 0) return (log_level)level;
+        }
+
+        // Default value
+        level = ERROR;
+    }
+    return (log_level)level;
+}
+
+void log_message(log_level level, const char* format, ...) {
+    if (level >= get_log_level())
+    {
+        va_list argptr;
+        va_start(argptr, format);
+        vfprintf(stderr, format, argptr);
+        va_end(argptr);
+    }
+}

--- a/libmemory-patches/logger.h
+++ b/libmemory-patches/logger.h
@@ -1,0 +1,9 @@
+typedef enum
+{
+    TRACE = 1,
+    INFO,
+    WARNING,
+    ERROR,
+} log_level;
+
+void log_message(log_level level, const char* format, ...);


### PR DESCRIPTION
Logs coming from libmemory-patches can be noisy, particularly when running containers with no memory limits. This change makes logging configurable via an environment variable 'LIBMEMORY_PATCHES_LOG_LEVEL'.