### PR TITLE
Modify libmemory-patches to short-circuit init for cgroups after failure

### DIFF
--- a/libmemory-patches/cgroups.c
+++ b/libmemory-patches/cgroups.c
@@ -487,9 +487,14 @@ static BOOL update_cgroup_memory_info(struct cgroup_memory_info *cg_mem_info)
 struct cgroup_memory_info *get_cgroup_memory_info(void)
 {
     static struct cgroup_memory_info cg_mem_info = { 0 };
+    static BOOL init_called = FALSE;
+
+    // Only attempt init_cgroup_memory_info() once
+    if (init_called && !cg_mem_info.initialised) return NULL;
 
     if (!cg_mem_info.initialised)
     {
+        init_called = TRUE;
         if (!init_cgroup_memory_info(&cg_mem_info))
         {
             log_message(WARNING, "cgroup_memory_info was not initialised\n");


### PR DESCRIPTION
This change modifies the behaviour of get_cgroup_memory_info() so that init_cgroup_memory_info() is only attempted once before reverting back to reading system stats from /proc/meminfo. This should avoid unnecessary overhead if initialization fails.