### PR TITLE
Fix sscanf return value checks in cgroups

### DIFF
--- a/libmemory-patches/cgroups.c
+++ b/libmemory-patches/cgroups.c
@@ -636,11 +636,11 @@ struct current_memory_info get_current_memory_info(void)
                     current_mem_info.totalswap += value * 1024;
                 else if(sscanf(line, "SwapFree: %llu kB", &value) == 1)
                     current_mem_info.freeswap += value * 1024;
-                else if (sscanf(line, "Buffers: %llu", &value))
+                else if (sscanf(line, "Buffers: %llu", &value) == 1)
                     current_mem_info.freeram += value * 1024;
-                else if (sscanf(line, "Cached: %llu", &value))
+                else if (sscanf(line, "Cached: %llu", &value) == 1)
                     current_mem_info.freeram += value * 1024;
-                else if (sscanf(line, "MemAvailable: %llu", &value))
+                else if (sscanf(line, "MemAvailable: %llu", &value) == 1)
                     mem_available = value * 1024;
             }
             fclose(fp);


### PR DESCRIPTION
Ensure sscanf checks return value for Buffers, Cached, and MemAvailable. scanf‑like functions should have their return values compared against the exact number of expected assignments (here, `1`), rather than simply tested for non‑zero. This ensures that partial matches, mismatches, or any other non‑successful cases are properly ignored.

In this file, the first four `sscanf` calls already use `== 1`. The last three (`"Buffers"`, `"Cached"`, `"MemAvailable"`) are used as `if (sscanf(...))`, which only checks for non‑zero. To align with the recommended pattern without changing functionality, update those three conditions to explicitly check `== 1`. Concretely, in `libmemory-patches/cgroups.c` around lines 639–643, change:
- `else if (sscanf(line, "Buffers: %llu", &value))` → `else if (sscanf(line, "Buffers: %llu", &value) == 1)`
- `else if (sscanf(line, "Cached: %llu", &value))` → `else if (sscanf(line, "Cached: %llu", &value) == 1)`
- `else if (sscanf(line, "MemAvailable: %llu", &value))` → `else if (sscanf(line, "MemAvailable: %llu", &value) == 1)`


### References
SEI CERT C++ Coding Standard: [ERR62-CPP. Detect errors when converting a string to a number](https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR62-CPP.+Detect+errors+when+converting+a+string+to+a+number)
SEI CERT C Coding Standard: [ERR33-C. Detect and handle standard library errors](https://wiki.sei.cmu.edu/confluence/display/c/ERR33-C.+Detect+and+handle+standard+library+errors)
cppreference.com: [scanf, fscanf, sscanf, scanf_s, fscanf_s, sscanf_s](https://en.cppreference.com/w/c/io/fscanf).