### PR TITLE
Add C++ compilation quickstart examples

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -7,6 +7,7 @@ This page presents a curated list of additional resources from external websites
 
 - [Wine-Enabled Containers section of the official Unreal Engine documentation](#wine-enabled-containers-section-of-the-official-unreal-engine-documentation)
 - [Asset cooking technical deep dive blog post](#asset-cooking-technical-deep-dive-blog-post)
+- [AutoSDK C++ compilation blog post](#autosdk-c-compilation-blog-post)
 
 
 ## Wine-Enabled Containers section of the official Unreal Engine documentation
@@ -21,3 +22,10 @@ The official Unreal Engine documentation includes a section titled *"Wine-Enable
 **Link:** <https://tensorworks.com.au/blog/migrating-unreal-engine-cook-workloads-to-wine/>
 
 The [TensorWorks](https://tensorworks.com.au/) blog post titled *"Migrating Unreal Engine cook workloads to Linux with Wine"* provides a technical deep-dive discussing the development of patches from this repository that improve the experience of deploying Unreal Engine asset cooking workloads in Linux containers with Wine.
+
+
+## AutoSDK C++ compilation blog post
+
+**Link:** <https://tensorworks.com.au/blog/unreal-engine-cpp-compilation-for-windows-under-wine/>
+
+The [TensorWorks](https://tensorworks.com.au/) blog post titled *"Unreal Engine C++ compilation for Windows under Linux with Wine"* provides an overview of the creation of the C++ compilation examples in the [quickstart](../examples/quickstart/) directory of this repository.

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,6 @@ Asset cooking workloads have been tested thoroughly, and most common cook scenar
 
 ## Code compilation workloads
 
-**Status:** Only partially supported for Win64, and still under active investigation
+**Status:** Supported for Win64, but still experimental
 
-Code compilation workloads targeting the Win64 platform have received preliminary testing, but there are a number of known issues and breakages. Some of these have been documented and addressed (see the [*Mitigations for Known Issues*](./mitigations.md) page for details), but there are still outstanding issues that have not yet been resolved. It is not yet possible to build Unreal Engine from source without modifying the code, and resources are not provided for doing so. It is recommended that developers wait until code compilation workloads have received further testing and refinement prior to attempting to run these workloads under Wine.
+Code compilation workloads targeting the Win64 platform have been tested thoroughly. There are a number of known issues and breakages, but these have been documented and addressed (see the [*Mitigations for Known Issues*](./mitigations.md) page for details). Most common compilation scenarios should function correctly when targeting the Win64 platform. Compilation for other target platforms is not guaranteed to function correctly.

--- a/examples/quickstart/autosdk/README.md
+++ b/examples/quickstart/autosdk/README.md
@@ -1,0 +1,47 @@
+# AutoSDK enabled image example
+
+This directory contains a [Dockerfile](./context/Dockerfile) and accompanying script for building a container image that extends the [base image containing Epic's patched version of Wine](../../../build/) and adds the Windows compiler toolchain files for use with the engine's [AutoSDK](https://dev.epicgames.com/documentation/en-us/unreal-engine/using-the-autosdk-system-in-unreal-engine) system. The resulting image can be used for building Unreal Engine itself from source, and as the basis for packaging Unreal Engine projects that contain C++ code. The script supports Unreal Engine 5.6.0 and newer.
+
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Building the Wine base image](#building-the-wine-base-image)
+- [Building the AutoSDK container image](#building-the-autosdk-container-image)
+- [Using the AutoSDK container image](#using-the-autosdk-container-image)
+
+
+## Prerequisites
+
+> [!IMPORTANT]
+> Different releases of Unreal Engine require different versions of the Windows toolchain components, so it is necessary to build an AutoSDK container image for the specific engine version that you are targeting. The Python script in this directory parses the SDK JSON file `Engine/Config/Windows/Windows_SDK.json` from the Unreal Engine source tree to determine which toolchain components to install. The format of this file became compatible with Python's JSON parser in [CL 39200598](https://github.com/EpicGames/UnrealEngine/commit/6f85c6f96fb7cbe7417514125ae64f15f6f2c40c), which is present in Unreal Engine 5.6.0 and newer. Older versions of Unreal Engine are not supported.
+
+- Unreal Engine source code (from either [GitHub](https://www.unrealengine.com/en-US/ue-on-github) or [Perforce](https://dev.epicgames.com/documentation/en-us/unreal-engine/accessing-unreal-engine-with-perforce)), version 5.6.0 or newer
+- [Docker Engine](https://docs.docker.com/engine/install/) version 23.0.0 or newer
+- [Python](https://www.python.org/) 3.7 or newer
+
+
+## Building the Wine base image
+
+The script in this directory will automatically build a base image containing Epic's patched version of Wine if it does not exist. If you wish to build the base image manually then simply follow the instructions in the [README for the repository's top-level **build** directory](../../../build/README.md).
+
+
+## Building the AutoSDK container image
+
+Run the appropriate wrapper script depending on the operating system, passing in the path to the root of the Unreal Engine source tree (the directory which contains the `Engine` subdirectory):
+
+- Under Linux and macOS, run `./assemble.sh </path/to/UE/source>`
+- Under Windows, run `.\assemble.bat <path\to\UE\source>`
+
+The wrapper script will run the Python build script itself, using the appropriate commands for the operating system. The Python build script will automatically determine which SDK components are required for the provided version of the engine. The script will then build the AutoSDK container image.
+
+Once the build completes, the container image will be available with the tag `epicgames/autosdk-wine:<VERSION>`, where `<VERSION>` is the version of Unreal Engine that the container image was built for.
+
+
+## Using the AutoSDK container image
+
+The functionality supported by the built AutoSDK container image depends on the version of Unreal Engine:
+
+- For Unreal Engine 5.6.0 and newer, the AutoSDK image can be used to package Unreal Engine projects that contain C++ code. For details, see the [**package-project**](../package-project/) directory.
+
+- For Unreal Engine 5.7.0 and newer, the AutoSDK image can also be used to build Unreal Engine itself from source. For details, see the [**create-installed-build**](../create-installed-build/) directory.

--- a/examples/quickstart/autosdk/assemble.bat
+++ b/examples/quickstart/autosdk/assemble.bat
@@ -1,0 +1,2 @@
+@rem Run the build script, propagating any command-line arguments
+python "%~dp0\assemble.py" %*

--- a/examples/quickstart/autosdk/assemble.py
+++ b/examples/quickstart/autosdk/assemble.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+import argparse, json, platform, re, subprocess, sys
+from pathlib import Path
+
+
+class Utility:
+	
+	@staticmethod
+	def log(message, leading_newline=False):
+		"""
+		Prints a log message to stderr
+		"""
+		print(
+			'[assemble.py]{}{}'.format(
+				'\n' if leading_newline == True else ' ',
+				message
+			),
+			file=sys.stderr,
+			flush=True
+		)
+	
+	@staticmethod
+	def error(message, leading_newline=False):
+		"""
+		Logs an error message and then exits immediately
+		"""
+		Utility.log('{}Error: {}'.format(
+			'\n' if leading_newline == True else '',
+			message
+		))
+		sys.exit(1)
+	
+	@staticmethod
+	def run(command, **kwargs):
+		"""
+		Logs and runs a command, verifying that the command succeeded
+		"""
+		stringified = [str(c) for c in command]
+		Utility.log(stringified)
+		return subprocess.run(stringified, **{'check': True, **kwargs})
+
+
+def report_missing_engine(source_path):
+	"""
+	Prints an error message reporting the absence of the required engine source files and then exits
+	"""
+	Utility.error('\n'.join([
+		'the specified path is not the root of a valid Unreal Engine source tree:',
+		str(source_path),
+		'',
+		'Note that only Unreal Engine 5.6 or newer is supported.'
+	]), leading_newline=True)
+
+def parse_windows_sdk_json(windows_sdk_json):
+	"""
+	Parses the SDK details in `Windows_SDK.json` from an Unreal Engine source tree
+	"""
+	data = json.loads(Path(windows_sdk_json).read_text('utf-8'))
+	
+	# Determine the newest version of Visual Studio that the engine supports
+	vs_version = None
+	for version in reversed(sorted([2022, 2026])):
+		if 'MinimumVisualStudio{}Version'.format(version) in data:
+			vs_version = version
+			break
+	
+	# Verify that the JSON is not malformed
+	if vs_version is None:
+		raise
+	
+	# Retrieve the Visual Studio major version number
+	vs_major = data['MinimumVisualStudio{}Version'.format(vs_version)].split('.', 1)[0]
+	
+	# Retrieve the general list of suggested components/workloads
+	suggested = data['VisualStudioSuggestedComponents']
+	
+	# Retrieve the version-specific list of suggested components/workloads
+	suggested += data['VisualStudio{}SuggestedComponents'.format(vs_version)]
+	
+	# Filter out any components/workloads that we know are not required (e.g. IDE workloads)
+	ignored = ['Component.Unreal', 'Microsoft.VisualStudio.Workload']
+	filter = lambda component: len([phrase for phrase in ignored if phrase in component]) == 0
+	suggested = [component for component in suggested if filter(component)]
+	
+	# Although the suggested components may list a .NET Framework targeting pack, we actually need the SDK
+	is_targeting_pack = lambda c: c.startswith('Microsoft.Net.Component') and c.endswith('TargetingPack')
+	suggested = [
+		component.replace('TargetingPack', 'SDK') if is_targeting_pack(component) else component
+		for component in suggested
+	]
+	
+	# Identify which .NET Framework SDK (if any) we need
+	pattern = re.compile(r'Microsoft\.Net\.Component\.(4\.[0-9]+\.[0-9]+)\.SDK')
+	matches = [pattern.fullmatch(component) for component in suggested]
+	matches = [match.group(1) for match in matches if match is not None]
+	dotnet_sdk = matches[0] if len(matches) > 0 else ''
+	
+	# Verify that we found at least one unfiltered component/workload
+	if len(suggested) == 0:
+		raise
+	
+	return {
+		'components': suggested,
+		'dotnet_sdk': dotnet_sdk,
+		'vs_identifier': 'VS{}'.format(vs_version),
+		'vs_version': vs_major
+	}
+
+
+# Parse our command-line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('engine_source', help='Path to the root of the Unreal Engine source tree')
+args = parser.parse_args()
+
+# Resolve the absolute paths to our input directories
+script_dir = Path(__file__).parent
+repo_root = script_dir.parent.parent.parent
+context_dir = script_dir / 'context'
+engine_dir = Path(args.engine_source) / 'Engine'
+
+# Verify that the specified engine source path is valid
+build_version = engine_dir / 'Build' / 'Build.version'
+windows_sdk_json = engine_dir / 'Config' / 'Windows' / 'Windows_SDK.json'
+if build_version.exists() == False or windows_sdk_json.exists() == False:
+	report_missing_engine(args.engine_source)
+
+# Attempt to detect the engine version
+engine_version = None
+try:
+	version_json = json.loads(build_version.read_text('utf-8'))
+	engine_version = '{}.{}.{}'.format(
+		version_json['MajorVersion'],
+		version_json['MinorVersion'],
+		version_json['PatchVersion']
+	)
+except:
+	report_missing_engine(args.engine_source)
+
+# Attempt to parse the SDK details in `Windows_SDK.json`
+sdk_details = None
+try:
+	sdk_details = parse_windows_sdk_json(windows_sdk_json)
+except:
+	report_missing_engine(args.engine_source)
+
+# Build our Wine base image with the default options
+# (This ensures mitigations are included, which are needed for .NET and C++ compilation)
+build_script = 'build.bat' if platform.system() == 'Windows' else 'build.sh'
+Utility.run([repo_root / 'build' / build_script])
+
+# Read the Wine version string so we know the base image tag
+wine_version_file = repo_root / 'build' / 'version.json'
+wine_version_contents = json.loads(wine_version_file.read_text('utf-8'))
+wine_version = wine_version_contents.get('wine-version')
+
+# Build our AutoSDK image
+image_tag = 'epicgames/autosdk-wine:{}'.format(engine_version)
+Utility.run([
+	'docker', 'buildx', 'build',
+	'--progress=plain',
+	'--platform', 'linux/amd64',
+	'--build-arg', 'COMPONENTS_AND_WORKLOADS={}'.format(' '.join(sdk_details['components'])),
+	'--build-arg', 'DOTNET_FRAMEWORK_SDK={}'.format(sdk_details['dotnet_sdk']),
+	'--build-arg', 'VISUAL_STUDIO_IDENTIFIER={}'.format(sdk_details['vs_identifier']),
+	'--build-arg', 'VISUAL_STUDIO_VERSION={}'.format(sdk_details['vs_version']),
+	'--build-arg', 'WINE_VERSION={}'.format(wine_version),
+	'-t', image_tag,
+	context_dir
+])
+
+# Report the build success
+print('', file=sys.stderr)
+Utility.log('Successfully built container image "{}"'.format(image_tag), leading_newline=True)

--- a/examples/quickstart/autosdk/assemble.sh
+++ b/examples/quickstart/autosdk/assemble.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+set -ex
+
+# Run the build script, propagating any command-line arguments
+python3 "$SCRIPT_DIR/assemble.py" "$@"

--- a/examples/quickstart/autosdk/context/Dockerfile
+++ b/examples/quickstart/autosdk/context/Dockerfile
@@ -1,0 +1,95 @@
+ARG WINE_VERSION='invalid'
+FROM epicgames/wine-patched:${WINE_VERSION} AS structure
+
+# The list of Visual Studio components and workloads to install
+ARG COMPONENTS_AND_WORKLOADS=''
+
+# The .NET Framework SDK to install (if any)
+ARG DOTNET_FRAMEWORK_SDK=''
+
+# The AutoSDK identifier for the version of Visual Studio (VS2019 / VS2022 / VS2026)
+ARG VISUAL_STUDIO_IDENTIFIER=''
+
+# The major version number for the version of Visual Studio (VS2019 == 16, VS2022 == 17, VS2026 == 18)
+ARG VISUAL_STUDIO_VERSION=''
+
+# Disable Wine debug logging while we assemble the AutoSDK directory structure
+ENV WINEDEBUG=-all
+
+# Install our required system packages
+USER root
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
+		git \
+		msitools \
+		python3
+
+# Clone the msvc-wine repository
+USER nonroot
+RUN git clone --depth=1 'https://github.com/mstorsjo/msvc-wine.git' /tmp/msvc-wine
+WORKDIR /tmp/msvc-wine
+
+# Install the requested Visual Studio components and workloads
+RUN python3 ./vsdownload.py \
+	--accept-license \
+	--skip-patch \
+	--cache ./cache \
+	--dest ./downloaded \
+	--major "$VISUAL_STUDIO_VERSION" \
+	$COMPONENTS_AND_WORKLOADS
+
+# Create the AutoSDK directory structure
+ENV AUTOSDK_DIR=/tmp/AutoSDK/HostWin64/Win64
+RUN mkdir -p "$AUTOSDK_DIR"
+RUN mkdir -p "$AUTOSDK_DIR/DIA SDK"
+RUN mkdir -p "$AUTOSDK_DIR/LLVM"
+
+# Move the files for the DIA SDK, MSVC and the Windows SDK into the AutoSDK structure
+RUN mv '/tmp/msvc-wine/downloaded/DIA SDK'       "$AUTOSDK_DIR/DIA SDK/$VISUAL_STUDIO_IDENTIFIER" && \
+	mv '/tmp/msvc-wine/downloaded/VC/Tools/MSVC' "$AUTOSDK_DIR/$VISUAL_STUDIO_IDENTIFIER" && \
+	mv '/tmp/msvc-wine/downloaded/Windows Kits'  "$AUTOSDK_DIR/Windows Kits"
+
+# Query the LLVM version and move the files for LLVM into the AutoSDK structure
+# (Note that we create a copy of the LLVM files before running clang, in case any first-run logic modifies the on-disk files)
+RUN cp -R '/tmp/msvc-wine/downloaded/VC/Tools/Llvm' /tmp/llvm && \
+	LLVM_VERSION=`wine /tmp/llvm/bin/clang-cl.exe --version | grep 'clang version' | grep -o -E '[0-9\.]+'` && \
+	mv '/tmp/msvc-wine/downloaded/VC/Tools/Llvm' "$AUTOSDK_DIR/LLVM/$LLVM_VERSION"
+
+# Extract the files for the .NET Framework SDK (if required) and move them into the AutoSDK structure
+RUN if [ ! -z "$DOTNET_FRAMEWORK_SDK" ]; then \
+		NETFXSDK_DIRECTORY=`find ./cache/ -iname "Microsoft.Net.$DOTNET_FRAMEWORK_SDK.SDK-4.*" -type d` && \
+		cd "$NETFXSDK_DIRECTORY" && \
+		msiextract ./sdk_tools*.msi && \
+		mv './Program Files/Windows Kits/NETFXSDK' "$AUTOSDK_DIR/Windows Kits/NETFXSDK"; \
+	fi
+
+# Locate the Windows SDK installer executable
+RUN WINSDK_INSTALLER=`find ./cache/ -iname winsdksetup.exe -type f` && \
+	cp "$WINSDK_INSTALLER" /tmp/winsdksetup.exe
+
+# Extract the Debugging Tools for Windows installer MSI from the Windows SDK installer executable
+RUN cd /tmp && \
+	wine winsdksetup.exe \
+		/layout ./winsdk_extracted \
+		/quiet \
+		/ceip off \
+		/features 'OptionID.WindowsDesktopDebuggers' && \
+	mv /tmp/winsdk_extracted/Installers /tmp/DebugTools
+
+# Extract the files for the Debugging Tools for Windows and copy them into the AutoSDK structure
+# (Note that we copy here rather than move, so we can merge the directory trees)
+RUN cd /tmp/DebugTools && \
+	msiextract './X64 Debuggers And Tools-x64_en-us.msi' && \
+	cd './Windows Kits' && \
+	cp -R * "$AUTOSDK_DIR/Windows Kits/"
+
+# Copy the assembled AutoSDK files into a clean version of our Wine base image
+FROM epicgames/wine-patched:${WINE_VERSION}
+COPY --from=structure --chown=nonroot:nonroot /tmp/AutoSDK ${WINEPREFIX}/drive_c/AutoSDK
+
+# Set the environment variable to configure Unreal Engine to use our AutoSDK files
+ENV UE_SDKS_ROOT=C:/AutoSDK
+
+# Disable Wine debug logging by default
+ENV WINEDEBUG=-all

--- a/examples/quickstart/create-installed-build/README.md
+++ b/examples/quickstart/create-installed-build/README.md
@@ -1,0 +1,54 @@
+# Create Installed Build example
+
+This directory contains a script for building Unreal Engine from source for Windows inside an [AutoSDK container image](../autosdk/). It supports Unreal Engine 5.7.0 and newer.
+
+> [!IMPORTANT]
+> Unlike most scripts in this repository, this script only supports being run under native Linux. It cannot be run under Windows or macOS with Docker Desktop, due to interactions between Wine's executable loader and the systems used to mount host filesystem directories into Linux containers under these platforms.
+
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Building the Wine and AutoSDK base images](#building-the-wine-and-autosdk-base-images)
+- [Building Unreal Engine from source](#building-unreal-engine-from-source)
+    - [Wrapping the Installed Build in a container image](#wrapping-the-installed-build-in-a-container-image)
+
+
+## Prerequisites
+
+- Unreal Engine source code (from either [GitHub](https://www.unrealengine.com/en-US/ue-on-github) or [Perforce](https://dev.epicgames.com/documentation/en-us/unreal-engine/accessing-unreal-engine-with-perforce)), version 5.7.0 or newer
+- [Docker Engine](https://docs.docker.com/engine/install/) version 23.0.0 or newer
+- [Python](https://www.python.org/) 3.7 or newer
+
+
+## Building the Wine and AutoSDK base images
+
+The script in this directory will automatically build the Wine and AutoSDK base images if they do not exist. If you wish to build them manually then simply follow the instructions in the relevant README files:
+
+- The README in the [repository's top-level **build** directory](../../../build/README.md) provides instructions for building a base image containing Epic's patched version of Wine.
+- The README in the [**autosdk** directory](../autosdk/README.md) provides instructions for building an image that contains the AutoSDK components required by your version of Unreal Engine.
+
+
+## Building Unreal Engine from source
+
+Run the wrapper script, passing in the path to the root of the Unreal Engine source tree (the directory which contains the `Engine` subdirectory):
+
+```bash
+./compile.sh </path/to/UE/source>
+```
+
+The wrapper script will run the Python build script itself. The Python build script will start a container using the appropriate AutoSDK base image and bind-mount the Unreal Engine source tree from the host filesystem into the container. The script will then build the engine from source, producing an [Installed Build](https://dev.epicgames.com/documentation/en-us/unreal-engine/installed-build-reference-guide-for-unreal-engine) which can be used under Windows or Wine.
+
+Once the build completes, the Installed Build will be available on the host filesystem at `</path/to/UE/source>/LocalBuilds/Engine/Windows`.
+
+### Wrapping the Installed Build in a container image
+
+By default, the Installed Build produced by the script only exists on the host filesystem. If you want to create a container image that includes the Installed Build files then you can specify the optional `--wrap` flag when running the script:
+
+```bash
+./compile.sh </path/to/UE/source> --wrap
+```
+
+This will automatically copy the the Installed Build files from the host filesystem into a container image. When this process completes, the container image will be available with the tag `epicgames/unreal-engine:dev-wine-<VERSION>`, where `<VERSION>` is the version of Unreal Engine that the container image was built for.
+
+Alternatively, you can create a container image from existing Installed Build files at any time by manually running the script in the [**wrap-installed-build**](../wrap-installed-build/) directory.

--- a/examples/quickstart/create-installed-build/compile.py
+++ b/examples/quickstart/create-installed-build/compile.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+import argparse, json, platform, shutil, subprocess, sys
+from pathlib import Path
+
+
+class Utility:
+	
+	@staticmethod
+	def log(message):
+		"""
+		Prints a log message to stderr
+		"""
+		print('[compile.py] {}'.format(message), file=sys.stderr, flush=True)
+	
+	@staticmethod
+	def error(message, leading_newline=False):
+		"""
+		Logs an error message and then exits immediately
+		"""
+		Utility.log('{}Error: {}'.format(
+			'\n' if leading_newline == True else '',
+			message
+		))
+		sys.exit(1)
+	
+	@staticmethod
+	def run(command, **kwargs):
+		"""
+		Logs and runs a command, verifying that the command succeeded
+		"""
+		stringified = [str(c) for c in command]
+		Utility.log(stringified)
+		return subprocess.run(stringified, **{'check': True, **kwargs})
+	
+	@staticmethod
+	def capture(command, **kwargs):
+		"""
+		Executes the specified command and captures its output
+		"""
+		return Utility.run(
+			command, **{'capture_output': True, 'encoding': 'utf-8', **kwargs}
+		).stdout.strip()
+
+	@staticmethod
+	def delete_recursive(path):
+		"""
+		Deletes the specified file or directory, performing recursive deletion for directories
+		"""
+		if path.is_dir():
+			shutil.rmtree(path)
+		else:
+			path.unlink()
+
+
+def report_missing_engine(source_path):
+	"""
+	Prints an error message reporting the absence of the required engine source files and then exits
+	"""
+	Utility.error('\n'.join([
+		'the specified path is not the root of a valid Unreal Engine source tree:',
+		str(source_path),
+		'',
+		'Note that only Unreal Engine 5.7 or newer is supported.'
+	]), leading_newline=True)
+
+
+# Parse our command-line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('engine_source', help='Path to the root of the Unreal Engine source tree')
+parser.add_argument('--wrap', action='store_true', help='Build a container image to wrap the Installed Build')
+args = parser.parse_args()
+
+# Resolve the absolute paths to our input directories
+script_dir = Path(__file__).parent
+quickstart_dir = script_dir.parent
+autosdk_dir = quickstart_dir / 'autosdk'
+wrap_dir = quickstart_dir / 'wrap-installed-build'
+engine_dir = Path(args.engine_source) / 'Engine'
+
+# Verify that the script is running under Linux
+if platform.system() != 'Linux':
+	Utility.error('This script must be run under Linux. Windows and macOS are not supported.')
+
+# If the script is running under WSL2, verify that the engine source is not located on the host Windows filesystem
+if 'microsoft' in platform.release():
+	
+	if not engine_dir.is_dir():
+		report_missing_engine(args.engine_source)
+	
+	engine_fs = Utility.capture(['stat', '--file-system', '--format="%T"', engine_dir])
+	if 'v9fs' in engine_fs:
+		Utility.error(' '.join([
+			'Cannot mount engine source from a Windows filesystem under WSL2.',
+			'Move the engine source into the Linux filesystem and retry.'
+		]))
+
+# Attempt to detect the engine version
+engine_version = None
+version_components = {}
+try:
+	build_version = engine_dir / 'Build' / 'Build.version'
+	version_components = json.loads(build_version.read_text('utf-8'))
+	engine_version = '{}.{}.{}'.format(
+		version_components['MajorVersion'],
+		version_components['MinorVersion'],
+		version_components['PatchVersion']
+	)
+except:
+	report_missing_engine(args.engine_source)
+
+# Verify that the engine is a supported version
+if version_components['MajorVersion'] < 5 or \
+   (version_components['MajorVersion'] == 5 and version_components['MinorVersion'] < 7):
+	report_missing_engine(args.engine_source)
+
+# Remove the ADOSupport plugin if it is present, since it breaks compilation under Wine
+# (Note that this plugin has been unused for many years and was officially removed in CL 50213900:
+#  https://github.com/EpicGames/UnrealEngine/commit/3d5026b1c9f28f99f2c18102f3e60d30b868cc80)
+ado_support_plugin = engine_dir / 'Plugins' / 'Runtime' / 'Database' / 'ADOSupport'
+if ado_support_plugin.exists():
+	Utility.log('Removing ADOSupport plugin: {}'.format(ado_support_plugin))
+	shutil.rmtree(ado_support_plugin)
+
+# Build an AutoSDK container image with the appropriate SDK version for the engine
+Utility.run(
+	[sys.executable, autosdk_dir / 'assemble.py', args.engine_source],
+	check=True
+)
+
+# Bind-mount the engine source into the AutoSDK container and create an Installed Build
+mount_path = '/home/nonroot/.local/share/wineprefixes/prefix/drive_c/UnrealEngine'
+Utility.run([
+	'docker', 'run', '--rm', '-t', '--init',
+	'-v', '{}:{}'.format(args.engine_source, mount_path),
+	'-w', mount_path,
+	'epicgames/autosdk-wine:{}'.format(engine_version),
+	'wine', './Engine/Build/BatchFiles/RunUAT.bat', 'BuildGraph',
+	'-script=Engine/Build/InstalledEngineBuild.xml',
+	'-target=Make Installed Build Win64',
+	'-set:HostPlatformOnly=true'
+])
+
+# Wrap the Installed Build in a container image if requested
+if args.wrap:
+	
+	# Clean out any existing contents in the target directory, except for the `.gitignore` file
+	target_dir = wrap_dir / 'context' / 'UnrealEngine'
+	Utility.log('Removing existing files in {}...'.format(target_dir))
+	for child in target_dir.iterdir():
+		if child.name != '.gitignore':
+			Utility.delete_recursive(child)
+	
+	# Copy the top-level directories from the Installed Build into the target directory
+	Utility.log('Copying Installed Build files to {}...'.format(target_dir))
+	installed_build = Path(args.engine_source) / 'LocalBuilds' / 'Engine' / 'Windows'
+	for child in installed_build.iterdir():
+		if child.is_dir():
+			shutil.copytree(child, target_dir / child.name)
+	
+	# Create the container image
+	Utility.run(
+		[sys.executable, wrap_dir / 'wrap.py'],
+		check=True
+	)

--- a/examples/quickstart/create-installed-build/compile.sh
+++ b/examples/quickstart/create-installed-build/compile.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+set -ex
+
+# Run the build script, propagating any command-line arguments
+python3 "$SCRIPT_DIR/compile.py" "$@"

--- a/examples/quickstart/package-project/README.md
+++ b/examples/quickstart/package-project/README.md
@@ -1,0 +1,58 @@
+# Package Project example
+
+This directory contains a script for packaging an Unreal Engine project for Windows using an [Installed Build](https://dev.epicgames.com/documentation/en-us/unreal-engine/installed-build-reference-guide-for-unreal-engine) inside an [AutoSDK container image](../autosdk/) under Linux. The script supports the use of Installed Build files stored on the host filesystem, or [wrapped in a container image](../wrap-installed-build/). It supports Unreal Engine 5.6.0 and newer.
+
+> [!IMPORTANT]
+> Unlike most scripts in this repository, this script only supports being run under native Linux. It cannot be run under Windows or macOS with Docker Desktop, due to interactions between Wine's executable loader and the systems used to mount host filesystem directories into Linux containers under these platforms.
+
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Building the Wine and AutoSDK base images](#building-the-wine-and-autosdk-base-images)
+- [Packaging the project](#packaging-the-project)
+    - [Using Installed Build files from the host filesystem](#using-installed-build-files-from-the-host-filesystem)
+    - [Using Installed Build files from a container image](#using-installed-build-files-from-a-container-image)
+
+
+## Prerequisites
+
+- Installed Build of Unreal Engine version 5.6.0 or newer, either stored on the host filesystem or [wrapped in a container image](../wrap-installed-build/)
+- Unreal Engine project compatible with the version of the engine
+- [Docker Engine](https://docs.docker.com/engine/install/) version 23.0.0 or newer
+- [Python](https://www.python.org/) 3.7 or newer
+
+
+## Building the Wine and AutoSDK base images
+
+The script in this directory will automatically build the Wine and AutoSDK base images if they do not exist. If you wish to build them manually then simply follow the instructions in the relevant README files:
+
+- The README in the [repository's top-level **build** directory](../../../build/README.md) provides instructions for building a base image containing Epic's patched version of Wine.
+- The README in the [**autosdk** directory](../autosdk/README.md) provides instructions for building an image that contains the AutoSDK components required by your version of Unreal Engine.
+
+
+## Packaging the project
+
+### Using Installed Build files from the host filesystem
+
+To perform packaging using Installed Build files located on the host filesystem, run the wrapper script with the path of both the `.uproject` file you wish to package and the path to the Installed Build files:
+
+```bash
+./package.sh --project </path/to/.uproject> --engine </path/to/UE/source>
+```
+
+The wrapper script will run the Python build script itself. The Python build script will start a container using the appropriate AutoSDK base image and bind-mount both the project source tree and the Installed Build files from the host filesystem into the container. The script will then package the project for Windows.
+
+Once packaging completes, the packaged files will be available on the host filesystem at `</path/to/.uproject>/dist`.
+
+### Using Installed Build files from a container image
+
+To perform packaging using Installed Build files that have been [wrapped in a container image](../wrap-installed-build/), run the wrapper script with the path of the `.uproject` file you wish to package and the container image tag:
+
+```bash
+./package.sh --project </path/to/.uproject> --image epicgames/unreal-engine:dev-wine-<VERSION>
+```
+
+The wrapper script will run the Python build script itself. The Python build script will start a container using the specified Installed Build container image and bind-mount the project source tree from the host filesystem into the container. The script will then package the project for Windows.
+
+Once packaging completes, the packaged files will be available on the host filesystem at `</path/to/.uproject>/dist`.

--- a/examples/quickstart/package-project/package.py
+++ b/examples/quickstart/package-project/package.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import argparse, json, platform, subprocess, sys
+from pathlib import Path
+
+class Utility:
+	
+	@staticmethod
+	def log(message):
+		"""
+		Prints a log message to stderr
+		"""
+		print('[package.py] {}'.format(message), file=sys.stderr, flush=True)
+	
+	@staticmethod
+	def error(message):
+		"""
+		Logs an error message and then exits immediately
+		"""
+		Utility.log('Error: {}'.format(message))
+		sys.exit(1)
+	
+	@staticmethod
+	def run(command, **kwargs):
+		"""
+		Logs and runs a command, verifying that the command succeeded
+		"""
+		stringified = [str(c) for c in command]
+		Utility.log(stringified)
+		return subprocess.run(stringified, **{'check': True, **kwargs})
+
+	@staticmethod
+	def capture(command, **kwargs):
+		"""
+		Executes the specified command and captures its output
+		"""
+		return Utility.run(
+			command, **{'capture_output': True, 'encoding': 'utf-8', **kwargs}
+		).stdout.strip()
+
+
+def check_v9fs_filesystem(path, description):
+	
+	if not path.is_dir():
+		Utility.error('The {} directory "{}" does not exist.'.format(description, path))
+	
+	fs_type = Utility.capture(['stat', '--file-system', '--format="%T"', path])
+	if 'v9fs' in fs_type:
+		Utility.error(' '.join([
+			'Cannot mount {} from a Windows filesystem under WSL2.'.format(description),
+			'Move the {} into the Linux filesystem and retry.'.format(description)
+		]))
+
+
+# Parse our command-line arguments
+parser = argparse.ArgumentParser()
+engine_build = parser.add_mutually_exclusive_group(required=True)
+engine_build.add_argument('--engine', help='Path to an Installed Build of Unreal Engine to use for packaging')
+engine_build.add_argument('--image', help='Tag of a container image encapsulating an Installed Build to use for packaging')
+parser.add_argument('--project', required=True, help='Path to the .uproject file of the Unreal Engine project to be packaged')
+args = parser.parse_args()
+
+# Resolve the absolute paths to our input directories
+script_dir = Path(__file__).parent
+autosdk_dir = script_dir.parent / 'autosdk'
+
+# Extract the parent directory and filename of the project
+project_path = Path(args.project)
+project_dir = project_path.parent
+project_file = project_path.name
+
+# Assemble the UAT `BuildCookRun` command to package the project
+package_command = [
+	'wine', 'C:/UnrealEngine/Engine/Build/BatchFiles/RunUAT.bat', 'BuildCookRun',
+	'-project=C:/project/{}'.format(project_file),
+	'-archive', '-archivedirectory=C:/project/dist',
+	'-platform=Win64', '-clientconfig=Development', '-serverconfig=Development',
+	'-nop4', '-allmaps', '-build', '-cook', '-stage', '-package', '-pak', '-iostore', '-compressed'
+]
+
+# Verify that the script is running under Linux
+if platform.system() != 'Linux':
+	Utility.error('This script must be run under Linux. Windows and macOS are not supported.')
+
+# If the script is running under WSL2, verify that the paths to be bind-mounted are not located on the host Windows filesystem
+if 'microsoft' in platform.release():
+	check_v9fs_filesystem(project_dir, 'project source')
+	if args.engine is not None:
+		check_v9fs_filesystem(Path(args.engine), 'Installed Build')
+
+# Determine whether we are bind-mounting an Installed Build from the host or using a container image that already wraps a build
+if args.engine is not None:
+	
+	# Ensure we have an AutoSDK container image with the appropriate SDK version for the engine
+	Utility.run(
+		[sys.executable, autosdk_dir / 'assemble.py', args.engine],
+		check=True
+	)
+	
+	# Attempt to detect the engine version (this should succeed if the AutoSDK script above succeeded)
+	build_version = Path(args.engine) / 'Engine' / 'Build' / 'Build.version'
+	version_json = json.loads(build_version.read_text('utf-8'))
+	engine_version = '{}.{}.{}'.format(
+		version_json['MajorVersion'],
+		version_json['MinorVersion'],
+		version_json['PatchVersion']
+	)
+	
+	# Bind-mount both the Installed Build and the project into the AutoSDK container and package the project
+	mount_root = Path('/home/nonroot/.local/share/wineprefixes/prefix/drive_c')
+	engine_mount = mount_root / 'UnrealEngine'
+	project_mount = mount_root / 'project'
+	Utility.run([
+		'docker', 'run', '--rm', '-it', '--init',
+		'-v', '{}:{}'.format(args.engine, engine_mount),
+		'-v', '{}:{}'.format(project_dir, project_mount),
+		'epicgames/autosdk-wine:{}'.format(engine_version),
+		] + package_command
+	)
+	
+else:
+	
+	# Bind-mount the project into the specified container and package the project
+	Utility.run([
+		'docker', 'run', '--rm', '-it', '--init',
+		'-v', '{}:/home/nonroot/.local/share/wineprefixes/prefix/drive_c/project'.format(project_dir),
+		args.image,
+		] + package_command
+	)

--- a/examples/quickstart/package-project/package.sh
+++ b/examples/quickstart/package-project/package.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+set -ex
+
+# Run the build script, propagating any command-line arguments
+python3 "$SCRIPT_DIR/package.py" "$@"

--- a/examples/quickstart/wrap-installed-build/README.md
+++ b/examples/quickstart/wrap-installed-build/README.md
@@ -1,15 +1,12 @@
 # Wrapped Installed Build example
 
-This directory contains a [Dockerfile](./context/Dockerfile) for building a container image that extends the [base image containing Epic's patched version of Wine](../../../build/) and adds the files for an Installed Build of Unreal Engine.
-
-> [!NOTE]
-> The container image built by these example files does not include a C++ compiler toolchain. As a result, it cannot be used to package Unreal Engine projects that include C++ code. The container image can be used to package projects that contain only Blueprint scripts.
+This directory contains a [Dockerfile](./context/Dockerfile) and accompanying script for building a container image that extends an [AutoSDK base image](../autosdk/) and adds the files for an [Installed Build](https://dev.epicgames.com/documentation/en-us/unreal-engine/installed-build-reference-guide-for-unreal-engine) of Unreal Engine. It supports Unreal Engine 5.6.0 and newer.
 
 
 ## Contents
 
 - [Prerequisites](#prerequisites)
-- [Building the Wine base image](#building-the-wine-base-image)
+- [Building the Wine and AutoSDK base images](#building-the-wine-and-autosdk-base-images)
 - [Building the container image](#building-the-container-image)
     - [Copying the Installed Build files](#copying-the-installed-build-files)
     - [Running the build script](#running-the-build-script)
@@ -17,34 +14,41 @@ This directory contains a [Dockerfile](./context/Dockerfile) for building a cont
 
 ## Prerequisites
 
-- Windows machine to download Unreal Engine binaries (but these can optionally be copied to a Linux or macOS machine to build the container image)
+- Installed Build of Unreal Engine, either copied from a Windows machine (version 5.6.0 or newer) or [built from source under Wine](../create-installed-build/) (version 5.7.0 or newer)
 - [Docker Engine](https://docs.docker.com/engine/install/) version 23.0.0 or newer
 - [Python](https://www.python.org/) 3.7 or newer
 
 
-## Building the Wine base image
+## Building the Wine and AutoSDK base images
 
-Follow the instructions in the [README for the repository's top-level build directory](../../../build/README.md) to build a base image containing Epic's patched version of Wine. Once the build completes, the base image will be available with the tag `epicgames/wine-patched:10.20`.
+The script in this directory will automatically build the Wine and AutoSDK base images if they do not exist. If you wish to build them manually then simply follow the instructions in the relevant README files:
+
+- The README in the [repository's top-level **build** directory](../../../build/README.md) provides instructions for building a base image containing Epic's patched version of Wine.
+- The README in the [**autosdk** directory](../autosdk/README.md) provides instructions for building an image that contains the AutoSDK components required by your version of Unreal Engine.
 
 
 ## Building the container image
 
 ### Copying the Installed Build files
 
-This example does not build Unreal Engine from source, but rather wraps an existing Installed Build that needs to be supplied by the user. You will need a Windows machine to download or build an Installed Build, but once the files have been obtained then the container image itself can be built under Linux, macOS or Windows.
+This example does not build Unreal Engine from source, but rather wraps an existing Installed Build that needs to be supplied by the user. You will either need a Windows machine to download or build an Installed Build of Unreal Engine 5.6.0 or newer, or for Unreal Engine 5.7.0 and newer you can [build the engine from source under Wine](../create-installed-build/) on a Linux machine. Either way, once the files have been obtained then the container image itself can be built under Linux, macOS or Windows.
 
-The recommended way to obtain an Installed Build is to install Unreal Engine via the Epic Games Launcher, by following these instructions: <https://dev.epicgames.com/documentation/en-us/unreal-engine/installing-unreal-engine>
+The recommended way to obtain an Installed Build under Windows is to install Unreal Engine via the Epic Games Launcher, by following these instructions: <https://dev.epicgames.com/documentation/en-us/unreal-engine/installing-unreal-engine>
 
-Alternatively, you can create an Installed Build by building Unreal Engine from source, by following these instructions: <https://dev.epicgames.com/documentation/en-us/unreal-engine/create-an-installed-build-of-unreal-engine>
+Alternatively, you can create an Installed Build by building Unreal Engine from source:
 
-Once you have obtained the Installed Build files, copy them to the [context/UnrealEngine](./context/UnrealEngine/) subdirectory. If the files have been copied correctly then the Unreal Editor executable should exist at the path:
+- For Unreal Engine 5.6.0 or newer, you can build the engine from source under Windows by following these instructions: <https://dev.epicgames.com/documentation/en-us/unreal-engine/create-an-installed-build-of-unreal-engine>
+
+- For Unreal Engine 5.7.0 or newer, you can build the engine from source under Wine by following the instructions in the [**create-installed-build**](../create-installed-build/) directory.
+
+Once you have obtained the Installed Build files, copy them to the [**context/UnrealEngine**](./context/UnrealEngine/) subdirectory. If the files have been copied correctly then the Unreal Editor executable should exist at the path:
 
 ```
 context/UnrealEngine/Engine/Binaries/Win64/UnrealEditor.exe
 ```
 
 > [!WARNING]
-> When copying the Installed Build files under Windows, you may encounter an error if any of the destination file paths exceed the [maximum path length limit](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation). To avoid this, either ensure the destination directory has a short path (e.g. by storing the local copy of this repository in the root of a drive, such as `C:\WineResources`), or follow Microsoft's [instructions to enable long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?#enable-long-paths-in-windows-10-version-1607-and-later).
+> When copying Installed Build files under Windows, you may encounter an error if any of the destination file paths exceed the [maximum path length limit](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation). To avoid this, either ensure the destination directory has a short path (e.g. by storing the local copy of this repository in the root of a drive, such as `C:\WineResources`), or follow Microsoft's [instructions to enable long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?#enable-long-paths-in-windows-10-version-1607-and-later).
 
 ### Running the build script
 
@@ -55,7 +59,7 @@ Run the appropriate wrapper script depending on the operating system:
 
 The wrapper script will run the Python build script itself, using the appropriate commands for the operating system. The Python build script will verify that the Installed Build files have been copied to the correct location, and will then automatically detect the version of Unreal Engine that the files represent. The script will then build the container image.
 
-Once the build completes, the container image will be available with the tag `epicgames/unreal-engine:dev-wine-blueprintonly-<VERSION>`, where `<VERSION>` is the version of Unreal Engine that the container image was built for. The image can be used to package Unreal Engine projects that contain only Blueprint scripts.
+Once the build completes, the container image will be available with the tag `epicgames/unreal-engine:dev-wine-<VERSION>`, where `<VERSION>` is the version of Unreal Engine that the container image was built for. The image can be used to package Unreal Engine projects, either manually or by using the script in the [**package-project**](../package-project/) directory.
 
 > [!IMPORTANT]
 > The Dockerfile step that copies the Installed Build files into the container image may take a long time to complete (i.e. over an hour on many systems, and potentially multiple hours under Windows when using Docker Desktop with WSL2). There is no output to indicate the progress of the copy operation, so it may appear to have frozen, but this is almost certainly not the case and you will simply need to wait for it to complete.

--- a/examples/quickstart/wrap-installed-build/context/Dockerfile
+++ b/examples/quickstart/wrap-installed-build/context/Dockerfile
@@ -1,9 +1,6 @@
 # Extend the base image containing the patched version of Wine
-ARG WINE_VERSION
-FROM epicgames/wine-patched:${WINE_VERSION}
-
-# Disable Wine debug logging
-ENV WINEDEBUG=-all
+ARG UE_VERSION='invalid'
+FROM epicgames/autosdk-wine:${UE_VERSION}
 
 # Copy the Installed Build of Unreal Engine to C:\UnrealEngine under our Wine prefix
 COPY --chown=nonroot:nonroot ./UnrealEngine ${WINEPREFIX}/drive_c/UnrealEngine

--- a/examples/quickstart/wrap-installed-build/wrap.bat
+++ b/examples/quickstart/wrap-installed-build/wrap.bat
@@ -1,0 +1,2 @@
+@rem Run the build script, propagating any command-line arguments
+python "%~dp0\wrap.py" %*

--- a/examples/quickstart/wrap-installed-build/wrap.py
+++ b/examples/quickstart/wrap-installed-build/wrap.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import json, subprocess, sys
+from pathlib import Path
+
+
+class Utility:
+	
+	@staticmethod
+	def log(message, leading_newline=False):
+		"""
+		Prints a log message to stderr
+		"""
+		print(
+			'[wrap.py]{}{}\n'.format(
+				'\n' if leading_newline == True else ' ',
+				message
+			),
+			file=sys.stderr,
+			flush=True
+		)
+	
+	@staticmethod
+	def error(message, leading_newline=False):
+		"""
+		Logs an error message and then exits immediately
+		"""
+		Utility.log('{}Error: {}'.format(
+			'\n' if leading_newline == True else '',
+			message
+		))
+		sys.exit(1)
+	
+	@staticmethod
+	def run(command, **kwargs):
+		"""
+		Logs and runs a command, returning the exit code
+		"""
+		stringified = [str(c) for c in command]
+		Utility.log(stringified)
+		return subprocess.run(stringified, **{'check': True, **kwargs}).returncode
+
+
+def report_missing_engine(editor_exe):
+	"""
+	Prints an error message reporting the absence of the required Installed Build files and then exits
+	"""
+	Utility.error('\n'.join([
+		'could not find valid Unreal Engine files!',
+		'',
+		'Please copy the files for a Win64 Installed Build to:',
+		str(unreal_dir),
+		'',
+		'You can create an Installed Build by building Unreal Engine from source using the script here:',
+		str(compile_dir),
+		'',
+		'Alternatively, you can copy the files from an Installed Build obtained via the Epic Games Launcher:',
+		'https://dev.epicgames.com/documentation/en-us/unreal-engine/installing-unreal-engine',
+		'',
+		'When the files have been copied correctly, the Unreal Editor executable should exist at this path:',
+		str(editor_exe),
+	]), leading_newline=True)
+
+
+# Resolve the absolute paths to our input directories
+script_dir = Path(__file__).parent
+autosdk_dir = script_dir.parent / 'autosdk'
+compile_dir = script_dir.parent / 'create-installed-build'
+repo_root = script_dir.parent.parent.parent
+context_dir = script_dir / 'context'
+unreal_dir = context_dir / 'UnrealEngine'
+engine_dir = unreal_dir / 'Engine'
+
+# Verify that the Installed Build files have been manually copied to the required location
+editor_exe = engine_dir / 'Binaries' / 'Win64' / 'UnrealEditor.exe'
+build_version = engine_dir / 'Build' / 'Build.version'
+if editor_exe.exists() == False or build_version.exists() == False:
+	report_missing_engine(editor_exe)
+
+# Attempt to detect the engine version of the Installed Build
+engine_version = None
+try:
+	version_json = json.loads(build_version.read_text('utf-8'))
+	engine_version = '{}.{}.{}'.format(
+		version_json['MajorVersion'],
+		version_json['MinorVersion'],
+		version_json['PatchVersion']
+	)
+except:
+	report_missing_engine(editor_exe)
+
+
+# Build an AutoSDK base image with the appropriate SDK version for the engine
+Utility.run(
+	[sys.executable, autosdk_dir / 'assemble.py', unreal_dir],
+	check=True
+)
+
+# Read the Wine version string so we know the base image tag
+wine_version_file = repo_root / 'build' / 'version.json'
+wine_version_contents = json.loads(wine_version_file.read_text('utf-8'))
+wine_version = wine_version_contents.get('wine-version')
+
+# Build the container image
+image_tag = 'epicgames/unreal-engine:dev-wine-{}'.format(engine_version)
+Utility.log('Detected files for Unreal Engine version {}'.format(engine_version))
+Utility.run([
+	'docker', 'buildx', 'build',
+	'--progress=plain',
+	'--platform', 'linux/amd64',
+	'--build-arg', 'UE_VERSION={}'.format(engine_version),
+	'-t', image_tag,
+	context_dir
+])
+
+# Report the build success and print our notice about the lack of a compiler toolchain
+print('', file=sys.stderr)
+Utility.log('Successfully built container image "{}"'.format(image_tag), leading_newline=True)

--- a/examples/quickstart/wrap-installed-build/wrap.sh
+++ b/examples/quickstart/wrap-installed-build/wrap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+set -ex
+
+# Run the build script, propagating any command-line arguments
+python3 "$SCRIPT_DIR/wrap.py" "$@"


### PR DESCRIPTION
Adds a series of scripts to build Unreal Engine and package C++ UE projects using AutoSDK in containers.

For more details see this [blog post](https://tensorworks.com.au/blog/unreal-engine-cpp-compilation-for-windows-under-wine/).
